### PR TITLE
feat: add load average plugin

### DIFF
--- a/Sources/TTXCMetricsClient/TTXCMetrics.swift
+++ b/Sources/TTXCMetricsClient/TTXCMetrics.swift
@@ -7,6 +7,7 @@ public struct TTXCMetrics {
     let metrics = XCMetrics.parseOrExit()
     let configuration = XCMetricsConfiguration()
     configuration.add(plugin: ThermalThrottlingPlugin().create())
+    configuration.add(plugin: LoadAveragePlugin().create())
 
     // The git directory is usually Xcode's `$SRCROOT` environment variable
     let gitDirectory: String? = ProcessInfo.processInfo.environment["SRCROOT"]

--- a/Sources/XCMetricsPlugins/LoadAveragePlugin.swift
+++ b/Sources/XCMetricsPlugins/LoadAveragePlugin.swift
@@ -1,0 +1,42 @@
+import Foundation
+import XCMetricsClient
+import XCMetricsUtils
+
+public struct LoadAveragePlugin {
+
+    private let shell: ShellOutFunction
+
+    public init(shell: @escaping ShellOutFunction = shellGetStdout) {
+        self.shell = shell
+    }
+
+    public func create() -> XCMetricsPlugin {
+        return XCMetricsPlugin(name: "Load Average", body: { _ -> [String : String] in
+            guard let uptimeStdout = try? shell("uptime", [], nil, nil) else { return [:] }
+
+            let loadAverages = parse(uptimeStdout)
+
+            if loadAverages.count == 3 {
+                return [
+                  "last_1_min_load_average": loadAverages[0],
+                  "last_5_min_load_average": loadAverages[1],
+                  "last_15_min_load_average": loadAverages[2],
+                  ]
+            } else {
+                return [:]
+            }
+        })
+    }
+
+    /// Takes the uptime command's output and returns an array
+    /// with the load averages in order: 1 min, 5 min, 15 min
+    private func parse(_ uptimeStdout: String) -> [String] {
+        let components = uptimeStdout.components(separatedBy: ",")
+
+        guard let loadAverages = components.last else { return [] }
+
+        let trimmedLoadAverages = loadAverages.replacingOccurrences(of: "load averages: ", with: "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return trimmedLoadAverages.split(separator: " ").map { String($0) }
+    }
+}


### PR DESCRIPTION
Collect the system's load average (1 min, 5 min, 15 min).

<img width="721" alt="image" src="https://github.com/user-attachments/assets/3f65e76f-e513-4fa3-b0b8-2202f6dc9d00">
