### PR TITLE
chore: update XCLogParser

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -437,8 +437,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MobileNativeFoundation/XCLogParser",
       "state" : {
-        "revision" : "e536e3009d391513a791e08b991d6fe413be0f9c",
-        "version" : "0.2.38"
+        "revision" : "251e44b6d28254802caf0a5dcdc6104ba465934c",
+        "version" : "0.2.40"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "XCMetricsUtils", targets: ["XCMetricsUtils"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/MobileNativeFoundation/XCLogParser", from: "0.2.38"),
+        .package(url: "https://github.com/MobileNativeFoundation/XCLogParser", from: "0.2.40"),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", exact: "0.2.7"),
         .package(url: "https://github.com/grpc/grpc-swift.git", exact: "1.0.0-alpha.9"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.3"),


### PR DESCRIPTION
This introduces support for Xcode >15.3 (including Xcode 16), while keeping support for older versions as well.